### PR TITLE
fix: corregir fecha del GTATimer y cálculo de días en index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,10 +8,12 @@ import statusData from '../data/status.json';
 
 const { coach, opponent, status, recentResults, fallenCoaches } = statusData;
 
-// Calculate days since start
+// Calculate days since start (timezone-safe, UTC dates)
 const startDate = new Date(coach.startDate);
 const now = new Date();
-const currentDays = Math.floor((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+const startUTC = Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate());
+const nowUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+const currentDays = Math.floor((nowUTC - startUTC) / (1000 * 60 * 60 * 24));
 
 // Icon mapping
 const getResultIcon = (result: string) => {
@@ -149,8 +151,8 @@ const pageTitle = `👑 REALTRONO — ${coach.name.toUpperCase()} | ${currentDay
             </div>
             <GTATimer 
                 client:load 
-                targetDate={coach.startDate} 
-                isCountdown={false}
+                targetDate={opponent.date} 
+                isCountdown={true}
                 title="" 
             />
         </section>


### PR DESCRIPTION
## Problemas
1. GTATimer recibía `coach.startDate` en vez de `opponent.date` → contaba desde el inicio del entrenador, no hacia el próximo partido
2. `isCountdown` estaba en `false` → contaba hacia arriba en vez de cuenta atrás
3. `currentDays` usaba cálculo sin timezone-safe (mismo bug del #1)

## Cambios
- `targetDate` → `opponent.date`
- `isCountdown` → `true`
- Cálculo UTC para `currentDays`

Closes #3